### PR TITLE
feat(MovieCard): implement three-tier image loading fallback strategy

### DIFF
--- a/components/home/MovieCard.tsx
+++ b/components/home/MovieCard.tsx
@@ -23,8 +23,8 @@ interface MovieCardProps {
 }
 
 export const MovieCard = memo(function MovieCard({ movie, onMovieClick }: MovieCardProps) {
-  const [imageError, setImageError] = useState(false);
-  const [fallbackError, setFallbackError] = useState(false);
+  const [imageSrc, setImageSrc] = useState(movie.cover);
+  const [isFinalError, setIsFinalError] = useState(false);
 
   return (
     <Link


### PR DESCRIPTION
# Description
Improved image error handling for movie card components. When a movie poster fails to load, the system now automatically attempts to load a fallback image. If the fallback also fails, a user-friendly text placeholder is displayed. This enhancement resolves the previous issue of repeated image loading caused by DOM manipulation and implements a more reliable degradation strategy through React state management.

## Related Issue
N/A

## Type of Change
- [x] 🐛 Bug fix
- [x] ♻️ Refactoring
- [x] ⚡️ Performance improvement

## Technical Details
- Replaced unreliable DOM manipulation with `useState` hooks for tracking image load states
- Implemented three-tier fallback strategy: primary image → fallback image → text placeholder
- Prevented infinite error loops from failed fallback images
- Optimized component performance through conditional rendering

## Checklist
- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented on hard-to-understand areas of my code
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes and verified they work as expected

## Screenshots/Recordings
Test scenarios:
- ✅ Image loads successfully
- ✅ Image fails to load, fallback image displayed
- ✅ Fallback image also fails, text placeholder displayed
- ✅ No more repeated loading attempts

### Before
<img width="1676" height="1248" alt="image" src="https://github.com/user-attachments/assets/a34af69d-7fa3-4400-a7ec-9a958e3d7a58" />


### After
<img width="1740" height="1274" alt="image" src="https://github.com/user-attachments/assets/7b210dc2-7033-4b7d-b9db-101d8b52145b" />
