### PR TITLE
style: Optimize card component layout and information display styles

### DIFF
--- a/components/home/MovieCard.tsx
+++ b/components/home/MovieCard.tsx
@@ -85,8 +85,8 @@ export const MovieCard = memo(function MovieCard({ movie, onMovieClick }: MovieC
             </div>
           )}
         </div>
-        <div className="p-3">
-          <h3 className="font-semibold text-sm text-[var(--text-color)] line-clamp-2 group-hover:text-[var(--accent-color)] transition-colors">
+        <div className="pt-3">
+          <h3 className="font-semibold text-sm text-center text-[var(--text-color)] line-clamp-2 group-hover:text-[var(--accent-color)] transition-colors">
             {movie.title}
           </h3>
         </div>

--- a/components/search/VideoCard.tsx
+++ b/components/search/VideoCard.tsx
@@ -139,15 +139,13 @@ export const VideoCard = memo<VideoCardProps>(({
                     </div>
 
                     {/* Info */}
-                    <div className="p-3 flex-1 flex flex-col">
-                        <h4 className="font-semibold text-sm text-[var(--text-color)] line-clamp-2 min-h-[2.5rem]">
+                    <div className="pt-3">
+                        <h4 className="font-semibold text-sm text-[var(--text-color)] line-clamp-2">
+                            {video.vod_remarks && (
+                                <span className="text-xs text-[var(--accent-color)] mr-1">[{video.vod_remarks}]</span>
+                            )}
                             {video.vod_name}
                         </h4>
-                        {video.vod_remarks && (
-                            <p className="text-xs text-[var(--text-color-secondary)] mt-1 line-clamp-1">
-                                {video.vod_remarks}
-                            </p>
-                        )}
                     </div>
                 </Card>
             </Link>


### PR DESCRIPTION
## Description

Optimized the layout and visual presentation of the `MovieCard` and `VideoCard` components.
- Unified the `padding` style in the bottom title section of the cards (changed from `p-3` to `pt-3`) for better UI consistency.
- Aligned the `MovieCard` title to the center (`text-center`).
- Refined the information hierarchy in `VideoCard` by moving `vod_remarks` (remarks) to the front of the title with accent color for quick identification of video status or episode updates.

## Related Issue
N/A

## Technical Details
- [x] 💄 Style/UI update

## Checklist
- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented on complex code sections
- [x] I have updated the relevant documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes and verified they work as expected

## Screenshots

### Before
<img width="1255" height="522" alt="image" src="https://github.com/user-attachments/assets/980f63f8-f18d-4d24-a245-09d1cc1913e3" />
<img width="1284" height="944" alt="image" src="https://github.com/user-attachments/assets/4e9b6119-bf40-48db-8326-40ab5cb113e3" />

### After
<img width="1247" height="515" alt="image" src="https://github.com/user-attachments/assets/5d717cda-abe4-4e5f-b0f8-09fecb8ed4a3" />
<img width="1295" height="1051" alt="image" src="https://github.com/user-attachments/assets/cea13930-a8c2-4f1e-a57d-3528e536d7d5" />

