### PR TITLE
Fix Android TV PiP bridge recursion

### DIFF
--- a/android-tv/app/src/main/java/com/kvideo/tv/MainActivity.kt
+++ b/android-tv/app/src/main/java/com/kvideo/tv/MainActivity.kt
@@ -340,11 +340,11 @@ class MainActivity : ComponentActivity() {
 
     private inner class AndroidPlayerBridge {
         @JavascriptInterface
-        fun isPictureInPictureSupported(): Boolean = isPictureInPictureSupported()
+        fun isPictureInPictureSupported(): Boolean = this@MainActivity.isPictureInPictureSupported()
 
         @JavascriptInterface
         fun enterPictureInPicture(width: Int, height: Int): Boolean {
-            if (!isPictureInPictureSupported()) {
+            if (!this@MainActivity.isPictureInPictureSupported()) {
                 return false
             }
 


### PR DESCRIPTION
## Summary
- fix the Android TV JavaScript bridge so PiP capability checks call the activity method instead of recursing into the bridge itself
- keep PiP entry using the activity-level support check before requesting Android PiP

## Root cause
- the JavaScript bridge method `isPictureInPictureSupported()` called itself instead of `MainActivity.isPictureInPictureSupported()`
- opening the player on Android TV could therefore trigger a `StackOverflowError` and surface the WebView "Application error" page

## Validation
- `npm run build`
- `npm run pages:build`
- validated `#150` runtime config flow with `NEXT_PUBLIC_SUBSCRIPTION_SOURCES` set to the provided GitHub Raw JSON source
- built `android-tv` debug APK and reproduced the original Android playback crash on an emulator
- rebuilt after this fix and verified normal playback, fullscreen, and PiP on the Android TV emulator