### PR TITLE
增加强制开启托管账户的环境变量

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ KVideo 现在支持两套认证模式：
 - 配置 `AUTH_SECRET`
 - 配置 `UPSTASH_REDIS_REST_URL`
 - 配置 `UPSTASH_REDIS_REST_TOKEN`
+- （可选）配置 `MANAGED_AUTH_ENABLED=true` 强制启用托管账户模式 （默认方式无法开启时可添加此环境变量）
 
 启用后：
 
@@ -277,6 +278,7 @@ KVideo 现在支持两套认证模式：
 - 超级管理员可在设置页直接管理账户和权限
 - 配置同步、历史、收藏等跨设备数据会按登录账户自动隔离
 
+> **强制启用托管模式**：设置 `MANAGED_AUTH_ENABLED=true` 可跳过 `AUTH_SECRET` 和 Redis 的检查，强制进入托管账户模式。
 首次启用时，如果 Redis 里还没有账户，会自动使用 `ADMIN_PASSWORD` 和 `ACCOUNTS` 作为引导种子创建首批托管账户。
 
 ### 方式二：单管理员密码（环境变量模式）

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ KVideo 现在支持两套认证模式：
 - 配置 `AUTH_SECRET`
 - 配置 `UPSTASH_REDIS_REST_URL`
 - 配置 `UPSTASH_REDIS_REST_TOKEN`
-- （可选）配置 `MANAGED_AUTH_ENABLED=true` 强制启用托管账户模式 （默认方式无法开启时可添加此环境变量）
+- （可选）配置 `MANAGED_AUTH_ENABLED=true` 强制优先使用托管账户模式
 
 启用后：
 
@@ -278,7 +278,7 @@ KVideo 现在支持两套认证模式：
 - 超级管理员可在设置页直接管理账户和权限
 - 配置同步、历史、收藏等跨设备数据会按登录账户自动隔离
 
-> **强制启用托管模式**：设置 `MANAGED_AUTH_ENABLED=true` 可跳过 `AUTH_SECRET` 和 Redis 的检查，强制进入托管账户模式。
+> **强制优先托管模式**：设置 `MANAGED_AUTH_ENABLED=true` 只会改变认证模式选择，不会跳过 `AUTH_SECRET` 和 Redis 检查。缺少 `AUTH_SECRET`、`UPSTASH_REDIS_REST_URL` 或 `UPSTASH_REDIS_REST_TOKEN` 时，托管账户模式仍不会启用。
 首次启用时，如果 Redis 里还没有账户，会自动使用 `ADMIN_PASSWORD` 和 `ACCOUNTS` 作为引导种子创建首批托管账户。
 
 ### 方式二：单管理员密码（环境变量模式）
@@ -682,6 +682,7 @@ docker run -e PORT=8080 -p 8080:8080 --name kvideo kuekhaoyang/kvideo:latest
 | 变量名 | 说明 | 默认值 |
 |--------|------|--------|
 | `AUTH_SECRET` | 托管账户模式的会话签名密钥；启用 Redis 托管账户时必填 | - |
+| `MANAGED_AUTH_ENABLED` | 设为 `true` 时强制优先使用托管账户模式；仍要求 `AUTH_SECRET` 和 Upstash Redis 配置完整 | - |
 | `ADMIN_PASSWORD` | 管理员密码；环境变量模式直接生效，也可作为托管模式首次引导的超级管理员种子 | - |
 | `ACCESS_PASSWORD` | 访问密码（向后兼容，等同于 `ADMIN_PASSWORD`） | - |
 | `ACCOUNTS` | 多账户配置；支持 `密码:名称[:角色[:权限1\|权限2]]` 和 `用户名:密码:名称[:角色[:权限1\|权限2]]` 两种格式 | - |

--- a/lib/server/auth-helpers.ts
+++ b/lib/server/auth-helpers.ts
@@ -5,6 +5,8 @@ import {
   type Role,
 } from '@/lib/auth/permissions';
 
+export type LoginMode = 'none' | 'legacy_password' | 'managed';
+
 export interface SeedAccountInput {
   username: string;
   password: string;
@@ -34,6 +36,24 @@ export interface SessionPayload {
   customPermissions?: Permission[];
   mode: 'managed' | 'legacy';
   iat: number;
+}
+
+export function resolveLoginMode({
+  managedAccountCount,
+  managedAuthEnabled,
+  managedAuthForced,
+  legacyAuthConfigured,
+}: {
+  managedAccountCount: number;
+  managedAuthEnabled: boolean;
+  managedAuthForced: boolean;
+  legacyAuthConfigured: boolean;
+}): LoginMode {
+  if (managedAccountCount > 0 || (managedAuthForced && managedAuthEnabled)) {
+    return 'managed';
+  }
+
+  return legacyAuthConfigured ? 'legacy_password' : 'none';
 }
 
 const PBKDF2_ITERATIONS = 120_000;

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -79,6 +79,7 @@ const IPTV_SOURCES = process.env.IPTV_SOURCES || process.env.NEXT_PUBLIC_IPTV_SO
 const MERGE_SOURCES = process.env.MERGE_SOURCES || process.env.NEXT_PUBLIC_MERGE_SOURCES || '';
 const DANMAKU_API_URL = process.env.DANMAKU_API_URL || process.env.NEXT_PUBLIC_DANMAKU_API_URL || '';
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+const MANAGED_AUTH_ENABLED = process.env.MANAGED_AUTH_ENABLED === 'true';
 
 const effectiveAdminPassword = ADMIN_PASSWORD || ACCESS_PASSWORD;
 
@@ -99,6 +100,9 @@ function getRedisClient(): Redis | null {
 }
 
 function isManagedAuthEnabled(): boolean {
+  if (MANAGED_AUTH_ENABLED) {
+    return true;
+  }
   return !!AUTH_SECRET && !!getRedisClient();
 }
 

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -7,9 +7,11 @@ import {
   hashPassword,
   normalizeUsername,
   parseBootstrapAccounts,
+  resolveLoginMode,
   signSessionPayload,
   verifyPassword,
   verifySessionToken,
+  type LoginMode,
   type SeedAccountInput,
   type SessionPayload,
   type StoredAccountRecord,
@@ -22,7 +24,7 @@ import {
   type Role,
 } from '@/lib/auth/permissions';
 
-export type LoginMode = 'none' | 'legacy_password' | 'managed';
+export type { LoginMode };
 
 export interface ServerAuthSession {
   accountId: string;
@@ -79,7 +81,7 @@ const IPTV_SOURCES = process.env.IPTV_SOURCES || process.env.NEXT_PUBLIC_IPTV_SO
 const MERGE_SOURCES = process.env.MERGE_SOURCES || process.env.NEXT_PUBLIC_MERGE_SOURCES || '';
 const DANMAKU_API_URL = process.env.DANMAKU_API_URL || process.env.NEXT_PUBLIC_DANMAKU_API_URL || '';
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
-const MANAGED_AUTH_ENABLED = process.env.MANAGED_AUTH_ENABLED === 'true';
+const MANAGED_AUTH_FORCED = process.env.MANAGED_AUTH_ENABLED === 'true';
 
 const effectiveAdminPassword = ADMIN_PASSWORD || ACCESS_PASSWORD;
 
@@ -100,9 +102,6 @@ function getRedisClient(): Redis | null {
 }
 
 function isManagedAuthEnabled(): boolean {
-  if (MANAGED_AUTH_ENABLED) {
-    return true;
-  }
   return !!AUTH_SECRET && !!getRedisClient();
 }
 
@@ -220,12 +219,14 @@ function getPublicRuntimeConfig(): Omit<PublicAuthConfig, 'hasAuth' | 'hasPremiu
 }
 
 export async function getPublicAuthConfig(): Promise<PublicAuthConfig> {
+  const managedAuthEnabled = isManagedAuthEnabled();
   const managedAccountCount = await getManagedAccountCount();
-  const loginMode: LoginMode = managedAccountCount > 0
-    ? 'managed'
-    : isLegacyAuthConfigured()
-      ? 'legacy_password'
-      : 'none';
+  const loginMode = resolveLoginMode({
+    managedAccountCount,
+    managedAuthEnabled,
+    managedAuthForced: MANAGED_AUTH_FORCED,
+    legacyAuthConfigured: isLegacyAuthConfigured(),
+  });
 
   return {
     hasAuth: loginMode !== 'none',

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -4,6 +4,7 @@ import {
   createStoredAccount,
   hashPassword,
   parseBootstrapAccounts,
+  resolveLoginMode,
   signSessionPayload,
   verifyPassword,
   verifySessionToken,
@@ -76,6 +77,22 @@ test('createStoredAccount stores hashed password and normalized permissions', as
   assert.equal(account.username, 'alice');
   assert.notEqual(account.passwordHash, 'secret');
   assert.equal(await verifyPassword('secret', account.passwordSalt, account.passwordHash), true);
+});
+
+test('MANAGED_AUTH_ENABLED does not bypass managed auth hard dependencies', () => {
+  assert.equal(resolveLoginMode({
+    managedAccountCount: 0,
+    managedAuthEnabled: false,
+    managedAuthForced: true,
+    legacyAuthConfigured: true,
+  }), 'legacy_password');
+
+  assert.equal(resolveLoginMode({
+    managedAccountCount: 0,
+    managedAuthEnabled: true,
+    managedAuthForced: true,
+    legacyAuthConfigured: true,
+  }), 'managed');
 });
 
 test('resolvePermissions applies role defaults and IPTV management inheritance', () => {


### PR DESCRIPTION
# 描述 (Description)

docker 部署项目后，redis一直没有生成账号，能看到数据库读取记录。因此添加此环境变量，跳过验证，完成项目部署。

增加强制开启托管账户的环境变量，在redis配置测试正常的情况下可以使用。

## 关联 Issue (Related Issue)

如果有相关的 Issue，请在这里链接 (例如: Fixes #123)。

## 更改类型 (Type of Change)

请删除不适用的选项：

- [ ] 📝 文档更新 (Documentation update)
- [ ] 🔧 配置更改 (Configuration change)

## 检查清单 (Checklist)

在提交 PR 之前，请确保您已完成以下检查：

- [ ] 我已阅读并遵守 [贡献指南](../CONTRIBUTING.md)
- [ ] 我的代码遵循项目的代码风格
- [ ] 我已对自己更改的代码进行了自我审查
- [ ] 我已注释了难以理解的代码部分
- [ ] 我已更新了相应的文档 (如果适用)
- [ ] 我的更改没有产生新的警告或错误
- [ ] 我已测试了我的更改，确保其按预期工作

## 截图/录屏 (Screenshots/Recordings)

如果您的更改涉及 UI/UX，请提供截图或录屏：
