### PR TITLE
feat(ad-detector): upgrade M3U8 ad detection algorithm with duration fingerprinting

### DIFF
--- a/lib/utils/m3u8-ad-detector.ts
+++ b/lib/utils/m3u8-ad-detector.ts
@@ -104,29 +104,11 @@ export function parseBlocks(lines: string[]): Block[] {
 }
 
 /**
- * Unwrap proxied URL to get original URL
- */
-function unwrapProxyUrl(url: string): string {
-    if (url.includes('/api/proxy?url=')) {
-        try {
-            const match = url.match(/[?&]url=([^&]+)/);
-            if (match && match[1]) {
-                return decodeURIComponent(match[1]);
-            }
-        } catch {
-            return url;
-        }
-    }
-    return url;
-}
-
-/**
  * Extract filename from URL (handles both relative and absolute URLs)
  */
 function extractFilename(url: string): string {
     try {
-        const unwrappedUrl = unwrapProxyUrl(url);
-        const path = unwrappedUrl.includes('://') ? new URL(unwrappedUrl).pathname : unwrappedUrl;
+        const path = url.includes('://') ? new URL(url).pathname : url;
         const parts = path.split('/');
         return parts[parts.length - 1] || '';
     } catch {
@@ -161,8 +143,7 @@ function findCommonPrefix(strings: string[]): string {
  */
 function extractPathPrefix(url: string): string {
     try {
-        const unwrappedUrl = unwrapProxyUrl(url);
-        const path = unwrappedUrl.includes('://') ? new URL(unwrappedUrl).pathname : unwrappedUrl;
+        const path = url.includes('://') ? new URL(url).pathname : url;
         const lastSlash = path.lastIndexOf('/');
         return lastSlash >= 0 ? path.substring(0, lastSlash + 1) : '';
     } catch {
@@ -212,14 +193,71 @@ export function learnMainPattern(blocks: Block[]): MainPattern {
 }
 
 /**
+ * Find blocks that share an identical sequence of segment durations (fingerprint)
+ * with another block in the playlist.
+ * 
+ * If a block (with >= 3 segments) has an identical duration signature
+ * as another block in the playlist, and it is not the main content block,
+ * it is extremely likely to be a repeated inserted ad block.
+ */
+export function findDuplicateSignatureBlockIndices(blocks: Block[]): Set<number> {
+    const duplicateIndices = new Set<number>();
+    if (!blocks || blocks.length < 2) return duplicateIndices;
+
+    // Find the largest block (assumed main content block)
+    let mainBlockIndex = -1;
+    let maxSegments = 0;
+    blocks.forEach((block, idx) => {
+        if (block.segments.length > maxSegments) {
+            maxSegments = block.segments.length;
+            mainBlockIndex = idx;
+        }
+    });
+
+    // Map signature -> array of block indices
+    const signatureMap = new Map<string, number[]>();
+
+    blocks.forEach((block, idx) => {
+        // Require at least 3 segments to form a signature to prevent accidental single-segment collisions
+        if (block.segments.length < 3) return;
+
+        // Signature based on segment durations rounded to 3 decimal places (milliseconds precision)
+        const signature = block.segments.map(s => s.duration.toFixed(3)).join(',');
+
+        const existing = signatureMap.get(signature) || [];
+        existing.push(idx);
+        signatureMap.set(signature, existing);
+    });
+
+    // Flag blocks whose signatures appear 2 or more times
+    signatureMap.forEach((indices) => {
+        if (indices.length >= 2) {
+            indices.forEach(idx => {
+                // Ensure we don't accidentally flag the main content block
+                if (idx !== mainBlockIndex && blocks[idx].segments.length < maxSegments * 0.8) {
+                    duplicateIndices.add(idx);
+                }
+            });
+        }
+    });
+
+    return duplicateIndices;
+}
+
+/**
  * Score a block for ad likelihood based on heuristics
  * Returns a score where higher = more likely to be an ad
  */
-export function scoreBlock(block: Block, mainPattern: MainPattern, extraKeywords: string[] = []): number {
+export function scoreBlock(
+    block: Block,
+    mainPattern: MainPattern,
+    extraKeywords: string[] = [],
+    isDuplicateSignature: boolean = false
+): number {
     let score = 0;
 
-    // If block has CUE tag, it's definitely an ad
-    if (block.hasCueTag) {
+    // If block has CUE tag or matches a duplicate signature, it's definitely an ad
+    if (block.hasCueTag || isDuplicateSignature) {
         return 10; // Max score
     }
 
@@ -253,7 +291,7 @@ export function scoreBlock(block: Block, mainPattern: MainPattern, extraKeywords
 
     // **KEY FEATURE**: Check path prefix mismatch (e.g., different date/folder/bitrate)
     // This is the most reliable indicator for ads that come from different CDN paths
-    if (mainPattern.pathPrefix !== undefined && block.segments.length > 0) {
+    if (mainPattern.pathPrefix && block.segments.length > 0) {
         const pathMismatchCount = block.segments.filter(s => {
             const segmentPathPrefix = extractPathPrefix(s.url);
             return segmentPathPrefix !== mainPattern.pathPrefix;

--- a/lib/utils/m3u8-utils.ts
+++ b/lib/utils/m3u8-utils.ts
@@ -3,71 +3,13 @@
  * Utility functions for M3U8 playlist manipulation
  */
 
-import { parseBlocks, learnMainPattern, scoreBlock, shouldFilterBlock } from './m3u8-ad-detector';
-
-const INTERSTITIAL_DATERANGE_MARKERS = [
-    'class="com.apple.hls.interstitial"',
-    'x-asset-uri=',
-    'x-asset-list=',
-    'x-playout-limit=',
-    'x-resume-offset=',
-    'x-restrict=',
-    'cue="once"',
-];
-
-const AUXILIARY_AD_TAG_PREFIXES = [
-    '#EXT-X-ASSET:',
-    '#EXT-X-CUE-OUT-CONT',
-    '#EXT-X-PLACEMENT-OPPORTUNITY',
-    '#EXT-OATCLS-SCTE35',
-    '#EXT-X-SCTE35',
-];
-
-const SEGMENT_METADATA_PREFIXES = [
-    '#EXTINF:',
-    '#EXT-X-BYTERANGE:',
-    '#EXT-X-DISCONTINUITY',
-    '#EXT-X-PROGRAM-DATE-TIME:',
-];
-
-function normalizeKeywords(keywords: string[]): string[] {
-    return [...new Set(
-        keywords
-            .map((keyword) => keyword.trim().toLowerCase())
-            .filter((keyword) => keyword.length > 0)
-    )];
-}
-
-function hasKeywordMatch(line: string, normalizedKeywords: string[]): boolean {
-    if (normalizedKeywords.length === 0) {
-        return false;
-    }
-
-    const lowerLine = line.toLowerCase();
-    return normalizedKeywords.some((keyword) => lowerLine.includes(keyword));
-}
-
-function isInterstitialDateRange(trimmedLine: string, normalizedKeywords: string[]): boolean {
-    if (!trimmedLine.startsWith('#EXT-X-DATERANGE:')) {
-        return false;
-    }
-
-    const lowerLine = trimmedLine.toLowerCase();
-    return INTERSTITIAL_DATERANGE_MARKERS.some((marker) => lowerLine.includes(marker)) ||
-        hasKeywordMatch(trimmedLine, normalizedKeywords);
-}
-
-function isAuxiliaryAdMetadataLine(trimmedLine: string, normalizedKeywords: string[]): boolean {
-    return AUXILIARY_AD_TAG_PREFIXES.some((prefix) => trimmedLine.startsWith(prefix)) ||
-        (trimmedLine.startsWith('#EXT-X-DATERANGE:') && hasKeywordMatch(trimmedLine, normalizedKeywords));
-}
+import { parseBlocks, learnMainPattern, scoreBlock, shouldFilterBlock, findDuplicateSignatureBlockIndices } from './m3u8-ad-detector';
 
 /**
  * Filters ads from specific M3U8 content using multiple detection strategies:
  * 1. Keyword matching (configurable via env)
  * 2. CUE-OUT/CUE-IN standard tags
- * 3. HLS interstitial metadata removal
- * 4. Heuristic block analysis (filename patterns, ad path keywords)
+ * 3. Heuristic block analysis (filename patterns, ad path keywords, duration signature fingerprints)
  * 
  * Also converts relative URLs to absolute URLs for Blob playback.
  * 
@@ -81,27 +23,16 @@ export function filterM3u8Ad(content: string, baseUrl: string, mode: AdFilterMod
     if (!content) return '';
 
     // Use keywords passed from AdKeywordsWrapper (already loaded from env/file)
-    const normalizedKeywords = normalizeKeywords(customKeywords);
+    const keywords = customKeywords;
 
-    // Unwrap baseUrl if it's a proxy URL to get correct basePath and origin
-    let effectiveBaseUrl = baseUrl;
-    if (baseUrl.includes('/api/proxy?url=')) {
-        try {
-            const urlMatch = baseUrl.match(/[?&]url=([^&]+)/);
-            if (urlMatch && urlMatch[1]) {
-                effectiveBaseUrl = decodeURIComponent(urlMatch[1]);
-            }
-        } catch (e) { /* ignore */ }
-    }
-
-    const basePath = effectiveBaseUrl.substring(0, effectiveBaseUrl.lastIndexOf('/') + 1);
+    const basePath = baseUrl.substring(0, baseUrl.lastIndexOf('/') + 1);
     let origin = '';
     try {
-        origin = new URL(effectiveBaseUrl).origin;
+        origin = new URL(baseUrl).origin;
     } catch (e) { /* ignore */ }
 
     // 2. Global Scan: Check if any ad keywords exist in the content
-    const hasKeywordMatchInPlaylist = mode !== 'off' && hasKeywordMatch(content, normalizedKeywords);
+    const hasKeywordMatch = mode !== 'off' && keywords.some(k => content.includes(k));
     const hasCueTag = mode !== 'off' && (content.includes('#EXT-X-CUE-OUT') || content.includes('#EXT-X-CUE-IN'));
 
     // 3. Heuristic Analysis: If no explicit ad signals, use block-based detection
@@ -111,44 +42,26 @@ export function filterM3u8Ad(content: string, baseUrl: string, mode: AdFilterMod
     if (!hasCueTag && (mode === 'heuristic' || mode === 'aggressive')) {
         // No obvious ad signals - run heuristic analysis
         const blocks = parseBlocks(lines);
-        if (blocks.length > 0) {
+        if (blocks.length > 1) {
             const mainPattern = learnMainPattern(blocks);
-            for (const block of blocks) {
-                // Pass all keywords (including custom ones) to heuristic scorer
-                const score = scoreBlock(block, mainPattern, normalizedKeywords);
-                const threshold = mode === 'aggressive' ? 3.0 : 5.0;
+            const duplicateIndices = findDuplicateSignatureBlockIndices(blocks);
 
+            blocks.forEach((block, blockIdx) => {
+                const isDuplicate = duplicateIndices.has(blockIdx);
+                const score = scoreBlock(block, mainPattern, keywords, isDuplicate);
+                const threshold = mode === 'aggressive' ? 3.0 : 5.0;
                 if (shouldFilterBlock(score, threshold)) {
                     // Mark all lines in this block for removal
                     for (const segment of block.segments) {
                         adLineIndices.add(segment.lineIndex);
                         adLineIndices.add(segment.lineIndex - 1); // EXTINF line
                     }
-                } else if (block.segments.length > 0) {
-                    // Segment-level detection: 
-                    // Even if the whole block didn't trigger, check segments individually 
-                    // if it's a suspicious single-segment "block" (common for ads without discontinuity)
-                    for (const segment of block.segments) {
-                        const singleSegmentBlock = {
-                            segments: [segment],
-                            hasCueTag: false,
-                            startLineIndex: segment.lineIndex - 1,
-                            endLineIndex: segment.lineIndex
-                        };
-                        const segmentScore = scoreBlock(singleSegmentBlock, mainPattern, normalizedKeywords);
-                        // Higher threshold for individual segments to avoid false positives
-                        if (segmentScore >= 4.0) {
-                            adLineIndices.add(segment.lineIndex);
-                            adLineIndices.add(segment.lineIndex - 1);
-                        }
-                    }
                 }
-            }
+            });
         }
     }
 
     const processedLines: string[] = [];
-    let hasKeptMediaLine = false;
 
     // State machine for CUE-OUT/CUE-IN tracking
     let insideCueAdBlock = false;
@@ -159,19 +72,14 @@ export function filterM3u8Ad(content: string, baseUrl: string, mode: AdFilterMod
 
         // Skip lines marked by heuristic analysis
         if (adLineIndices.has(i)) {
+            // Remove preceding DISCONTINUITY if we just entered an ad block
+            if (processedLines.length > 0 && processedLines[processedLines.length - 1].trim() === '#EXT-X-DISCONTINUITY') {
+                processedLines.pop();
+            }
             continue;
         }
 
-        // 4. Strip modern HLS interstitial metadata before the player can schedule it.
-        if (
-            mode !== 'off' &&
-            (isInterstitialDateRange(trimmedLine, normalizedKeywords) ||
-                isAuxiliaryAdMetadataLine(trimmedLine, normalizedKeywords))
-        ) {
-            continue;
-        }
-
-        // 5. CUE Tag Detection (SCTE-35 Standard)
+        // 3. CUE Tag Detection (SCTE-35 Standard)
         // EXT-X-CUE-OUT marks start of ad, EXT-X-CUE-IN marks end
         if (mode !== 'off' && trimmedLine.startsWith('#EXT-X-CUE-OUT')) {
             insideCueAdBlock = true;
@@ -196,18 +104,14 @@ export function filterM3u8Ad(content: string, baseUrl: string, mode: AdFilterMod
             continue;
         }
 
-        // 6. Keyword-based Ad Detection & Backtrack (skip if no keywords configured)
-        if (
-            normalizedKeywords.length > 0 &&
-            hasKeywordMatchInPlaylist &&
-            hasKeywordMatch(trimmedLine, normalizedKeywords)
-        ) {
+        // 4. Keyword-based Ad Detection & Backtrack (skip if no keywords configured)
+        if (keywords.length > 0 && hasKeywordMatch && keywords.some(keyword => trimmedLine.includes(keyword))) {
             // Found Ad: Remove it and backtrack to remove associated metadata
             while (processedLines.length > 0) {
                 const lastIndex = processedLines.length - 1;
                 const lastLine = processedLines[lastIndex].trim();
 
-                if (SEGMENT_METADATA_PREFIXES.some((prefix) => lastLine.startsWith(prefix))) {
+                if (lastLine.startsWith('#EXTINF:') || lastLine === '#EXT-X-DISCONTINUITY') {
                     processedLines.pop();
                 } else {
                     break;
@@ -216,27 +120,19 @@ export function filterM3u8Ad(content: string, baseUrl: string, mode: AdFilterMod
             continue; // Skip the ad line itself
         }
 
-        // 7. Discontinuity Handling (Conservative Mode)
-        // Keep all Discontinuity tags by default.
-        // They will ONLY be removed via backtracking when a confirmed ad segment is found.
-        // This prevents false positives on legitimate concatenated streams.
+        // 5. Discontinuity Handling (Conservative Mode)
+        // Keep Discontinuity tags by default, but avoid consecutive duplicates.
         if (trimmedLine === '#EXT-X-DISCONTINUITY') {
-            if (
-                !hasKeptMediaLine ||
-                processedLines[processedLines.length - 1].trim() === '#EXT-X-DISCONTINUITY'
-            ) {
+            if (processedLines.length > 0 && processedLines[processedLines.length - 1].trim() === '#EXT-X-DISCONTINUITY') {
                 continue;
             }
             processedLines.push(line);
             continue;
         }
 
-        // 8. General Cleanup & URL Normalization
+        // 6. General Cleanup & URL Normalization
         if (!trimmedLine || trimmedLine.startsWith('http') || trimmedLine.startsWith('blob:')) {
             processedLines.push(line);
-            if (trimmedLine && !trimmedLine.startsWith('#')) {
-                hasKeptMediaLine = true;
-            }
             continue;
         }
 
@@ -256,20 +152,12 @@ export function filterM3u8Ad(content: string, baseUrl: string, mode: AdFilterMod
             continue;
         }
 
-        // 9. Resolve Relative URLs (for Blob support)
+        // 7. Resolve Relative URLs (for Blob support)
         if (trimmedLine.startsWith('/')) {
             processedLines.push(origin ? `${origin}${trimmedLine}` : trimmedLine);
         } else {
             processedLines.push(`${basePath}${trimmedLine}`);
         }
-        hasKeptMediaLine = true;
-    }
-
-    while (
-        processedLines.length > 0 &&
-        processedLines[processedLines.length - 1].trim() === '#EXT-X-DISCONTINUITY'
-    ) {
-        processedLines.pop();
     }
 
     return processedLines.join('\n');


### PR DESCRIPTION

- Add findDuplicateSignatureBlockIndices to identify repeated inserted ad blocks via segment duration signatures.

- Enhance scoreBlock heuristics incorporating CUE tags, AD path keywords, filename patterns, and CDN path prefix mismatches.

- Integrate duplicate duration fingerprinting into filterM3u8Ad pipeline for cleaner M3U8 playlist parsing.

