### PR TITLE
fix(sync): 修复自托管下 /api/user/{sync,config} 无法读取 Upstash 配置

### DIFF
--- a/app/api/user/config/route.ts
+++ b/app/api/user/config/route.ts
@@ -5,18 +5,23 @@
  * so they persist across browsers, devices, and PWA installs.
  */
 
-import { Redis } from '@upstash/redis/cloudflare';
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticationRequiredResponse } from '@/lib/server/api-responses';
 import { getServerSession } from '@/lib/server/auth';
+import { getRedisClient } from '@/lib/server/redis';
 
 export const runtime = 'edge';
-
-const redis = Redis.fromEnv();
 
 function redisKey(profileId: string): string {
   const safe = profileId.replace(/[^a-zA-Z0-9_-]/g, '');
   return `user:config:${safe}`;
+}
+
+function syncUnavailableResponse() {
+  return NextResponse.json(
+    { error: 'Server-side sync is not configured on this deployment' },
+    { status: 503 }
+  );
 }
 
 export async function GET(request: NextRequest) {
@@ -25,6 +30,11 @@ export async function GET(request: NextRequest) {
 
   if (!profileId) {
     return authenticationRequiredResponse();
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    return syncUnavailableResponse();
   }
 
   try {
@@ -45,6 +55,11 @@ export async function POST(request: NextRequest) {
 
   if (!profileId) {
     return authenticationRequiredResponse();
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    return syncUnavailableResponse();
   }
 
   try {

--- a/app/api/user/sync/route.ts
+++ b/app/api/user/sync/route.ts
@@ -1,19 +1,29 @@
-import { Redis } from '@upstash/redis/cloudflare';
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticationRequiredResponse } from '@/lib/server/api-responses';
 import { getServerSession } from '@/lib/server/auth';
+import { getRedisClient } from '@/lib/server/redis';
 
 // 确保这行代码在整个文件中只出现一次
 export const runtime = 'edge';
 
-const redis = Redis.fromEnv();
+function syncUnavailableResponse() {
+  return NextResponse.json(
+    { error: 'Server-side sync is not configured on this deployment' },
+    { status: 503 }
+  );
+}
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(request);
   const profileId = session?.profileId;
-  
+
   if (!profileId) {
     return authenticationRequiredResponse();
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    return syncUnavailableResponse();
   }
 
   try {
@@ -31,9 +41,14 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const session = await getServerSession(request);
   const profileId = session?.profileId;
-  
+
   if (!profileId) {
     return authenticationRequiredResponse();
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    return syncUnavailableResponse();
   }
 
   try {

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -1,6 +1,6 @@
-import { Redis } from '@upstash/redis/cloudflare';
-import { getOptionalRequestContext } from '@cloudflare/next-on-pages';
 import { NextRequest, NextResponse } from 'next/server';
+import { getRedisClient } from '@/lib/server/redis';
+import { getRuntimeEnvValue } from '@/lib/server/runtime-env';
 import { getRuntimeFeatures } from '@/lib/server/runtime-features';
 import {
   createStoredAccount,
@@ -87,49 +87,16 @@ const DANMAKU_API_URL = process.env.DANMAKU_API_URL || process.env.NEXT_PUBLIC_D
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 const MANAGED_AUTH_FORCED = process.env.MANAGED_AUTH_ENABLED === 'true';
 
-function getRuntimeEnvValue(name: string, fallback = ''): string {
-  try {
-    const runtimeEnv = getOptionalRequestContext()?.env as unknown as Record<string, unknown> | undefined;
-    const value = runtimeEnv?.[name];
-    if (typeof value === 'string') return value;
-  } catch {
-    // Outside Cloudflare's request runtime, fall back to process.env.
-  }
-
-  return process.env[name] || fallback;
-}
-
 function getEffectiveAdminPassword(): string {
   return getRuntimeEnvValue('ADMIN_PASSWORD', ADMIN_PASSWORD) ||
     getRuntimeEnvValue('ACCESS_PASSWORD', ACCESS_PASSWORD);
 }
-
-let cachedRedis: Redis | null | undefined;
 
 export class ManagedAuthStorageError extends Error {
   constructor(operation: 'read' | 'write', cause?: unknown) {
     super(`Managed auth storage ${operation} failed`, { cause });
     this.name = 'ManagedAuthStorageError';
   }
-}
-
-function getRedisClient(): Redis | null {
-  if (cachedRedis !== undefined) {
-    return cachedRedis;
-  }
-
-  const url = getRuntimeEnvValue('UPSTASH_REDIS_REST_URL');
-  const token = getRuntimeEnvValue('UPSTASH_REDIS_REST_TOKEN');
-  if (!url || !token) {
-    cachedRedis = null;
-    return cachedRedis;
-  }
-
-  cachedRedis = new Redis({
-    url,
-    token,
-  });
-  return cachedRedis;
 }
 
 function isManagedAuthEnabled(): boolean {

--- a/lib/server/redis.ts
+++ b/lib/server/redis.ts
@@ -1,0 +1,36 @@
+import { Redis } from '@upstash/redis/cloudflare';
+
+import { getRuntimeEnvValue } from '@/lib/server/runtime-env';
+
+let cachedRedis: Redis | null | undefined;
+
+/**
+ * Build the shared Upstash client from whichever environment source is available.
+ *
+ * `Redis.fromEnv()` is deliberately not used here: the `@upstash/redis/cloudflare`
+ * implementation only reads Cloudflare's global bindings and never falls back to
+ * `process.env`, so it always resolves to `undefined` on Docker / Node
+ * self-hosted deployments. The client is also created lazily because Cloudflare's
+ * per-request bindings are not reachable while a module is being evaluated.
+ *
+ * Returns `null` when Upstash is not configured, which callers should treat as
+ * "server-side sync unavailable" rather than as a request failure.
+ */
+export function getRedisClient(): Redis | null {
+  if (cachedRedis !== undefined) {
+    return cachedRedis;
+  }
+
+  const url = getRuntimeEnvValue('UPSTASH_REDIS_REST_URL');
+  const token = getRuntimeEnvValue('UPSTASH_REDIS_REST_TOKEN');
+  if (!url || !token) {
+    cachedRedis = null;
+    return cachedRedis;
+  }
+
+  cachedRedis = new Redis({
+    url,
+    token,
+  });
+  return cachedRedis;
+}

--- a/lib/server/runtime-env.ts
+++ b/lib/server/runtime-env.ts
@@ -1,0 +1,20 @@
+import { getOptionalRequestContext } from '@cloudflare/next-on-pages';
+
+/**
+ * Read an environment value that may live in either runtime environment.
+ *
+ * On Cloudflare, bindings and secrets are only reachable through the
+ * per-request context. On Docker / Node self-hosting there is no such context,
+ * so the value comes from `process.env`.
+ */
+export function getRuntimeEnvValue(name: string, fallback = ''): string {
+  try {
+    const runtimeEnv = getOptionalRequestContext()?.env as unknown as Record<string, unknown> | undefined;
+    const value = runtimeEnv?.[name];
+    if (typeof value === 'string') return value;
+  } catch {
+    // Outside Cloudflare's request runtime, fall back to process.env.
+  }
+
+  return process.env[name] || fallback;
+}


### PR DESCRIPTION
# 描述 (Description)

修复 Docker / 传统 Node.js 自托管部署下 `/api/user/sync` 与 `/api/user/config` 恒返回 500 的问题，跨设备同步（收藏、历史、设置）因此完全不可用。

这两个路由用 `@upstash/redis/cloudflare` 的 `Redis.fromEnv()` 创建客户端，而该实现只读传入的 `env` 参数或 Cloudflare 全局绑定，**从不回退到 `process.env`**。调用处没有传 `env`，Docker / Node 环境里也不存在那两个全局标识符，于是 `url` 与 `token` 恒为 `undefined`。

容易误导的一点是：认证走的是 `lib/server/auth.ts` 里的 `new Redis({ url, token })` + `getRuntimeEnvValue()` 双源回退，所以**登录完全正常、能拿到 `super_admin` 会话**，唯独用户数据读写全挂。

### 改动内容

- 新增 `lib/server/runtime-env.ts`：把 `auth.ts` 里已有的 `getRuntimeEnvValue()`（Cloudflare per-request 绑定 → `process.env` 回退）抽成共享模块，行为不变。
- 新增 `lib/server/redis.ts`：`getRedisClient()` 惰性创建共享客户端，未配置时返回 `null`。这段逻辑同样是从 `auth.ts` 平移出来的。
- `lib/server/auth.ts`：改为引用上述两个模块，删除重复实现（-35 行），逻辑不变。
- `app/api/user/{sync,config}/route.ts`：改用 `getRedisClient()`；未配置 Upstash 时返回 `503` 并说明原因，而不是把它当成请求失败。

顺带修正了一个隐患：原先客户端在**模块作用域**创建，而 Cloudflare 的 per-request 绑定在模块求值阶段并不可达，惰性创建后两个运行时都更稳妥。

## 关联 Issue (Related Issue)

Fixes #226

## 更改类型 (Type of Change)

- [x] 🐛 Bug 修复 (Bug fix)

## 检查清单 (Checklist)

- [x] 我已阅读并遵守 [贡献指南](../CONTRIBUTING.md)
- [x] 我的代码遵循项目的代码风格
- [x] 我已对自己更改的代码进行了自我审查
- [x] 我已注释了难以理解的代码部分
- [x] 我已更新了相应的文档 (如果适用) —— 本次为纯行为修复，未涉及文档
- [x] 我的更改没有产生新的警告或错误
- [x] 我已测试了我的更改，确保其按预期工作

## 验证 (Verification)

**1. 现有测试与静态检查**

```
npm test                 → 73 tests, 73 pass, 0 fail
npx tsc --noEmit         → 改动文件无报错（仓库既有的 tests/auth.test.ts 报错与本次无关）
npx eslint <改动的 5 个文件>  → 无输出
```

新增文件均远低于贡献指南的 150 行上限（20 行 / 36 行），`auth.ts` 反而减少 35 行。

**2. 构建产物比对**

```
修复前（v4.9.17 镜像内）：
  .next/server/app/api/user/sync/route.js    → .fromEnv( 调用 1 处
  .next/server/app/api/user/config/route.js  → .fromEnv( 调用 1 处

修复后（npm run build）：
  .next/server/app/api/user/sync/route.js    → .fromEnv( 调用 0 处
  .next/server/app/api/user/config/route.js  → .fromEnv( 调用 0 处
```

**3. 真实自托管环境验证**

在一台 Docker 主机上以托管账户模式（`AUTH_SECRET` + Upstash REST 端点）运行官方镜像：

```
修复前:
  POST /api/auth        200  {"valid":true, "role":"super_admin", "mode":"managed"}
  GET  /api/user/sync   500  {"error":"Failed to fetch sync data"}
  GET  /api/user/config 500  {"error":"Failed to read config"}
  日志: [Upstash Redis] Unable to find environment variables ...

应用等效修复后:
  GET  /api/user/sync   200  {"success":true,"data":{"history":[...],"favorites":[...]}}
  GET  /api/user/config 200  {"success":true,"data":{"sources":[...],"locale":"zh-CN"}}
  POST /api/user/sync   200  写入后回读一致
  日志: 无 Upstash 告警
```

**4. 关于单元测试**

本想为 `getRuntimeEnvValue()` / `getRedisClient()` 补测试，但它们（经 `@cloudflare/next-on-pages`）在当前 `tsx --test` 环境下无法加载：

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
  node_modules/@cloudflare/next-on-pages/package.json
```

这也是现有测试都只覆盖纯模块的原因。为不扩大本 PR 的范围，没有改动测试基建；如果你希望补上这块覆盖，我可以另开一个 PR 处理。

## 截图/录屏 (Screenshots/Recordings)

本次为服务端行为修复，无 UI 变更。
