### PR TITLE
fix(sync): 丢弃缺少 videoId 的同步记录，避免整页崩溃

### DIFF
--- a/components/favorites/FavoritesList.tsx
+++ b/components/favorites/FavoritesList.tsx
@@ -5,6 +5,7 @@
 import type { FavoriteItem } from '@/lib/types';
 import { FavoritesItem } from './FavoritesItem';
 import { FavoritesEmptyState } from './FavoritesEmptyState';
+import { keepRenderableFavorites } from '@/lib/utils/sync-records';
 
 interface FavoritesListProps {
     favorites: FavoriteItem[];
@@ -19,7 +20,7 @@ export function FavoritesList({ favorites, onRemove, isPremium = false }: Favori
 
     return (
         <div className="flex-1 overflow-y-auto -mx-2 px-2 space-y-2 scroll-smooth">
-            {favorites.map((item) => (
+            {keepRenderableFavorites(favorites).map((item) => (
                 <FavoritesItem
                     key={`${item.source}:${item.videoId}`}
                     item={item}

--- a/components/history/HistoryList.tsx
+++ b/components/history/HistoryList.tsx
@@ -1,6 +1,7 @@
 import { HistoryItem } from './HistoryItem';
 import { HistoryEmptyState } from './HistoryEmptyState';
 import type { VideoHistoryItem } from '@/lib/types';
+import { keepRenderableHistory } from '@/lib/utils/sync-records';
 
 interface HistoryListProps {
     history: VideoHistoryItem[];
@@ -18,7 +19,7 @@ export function HistoryList({ history, onRemove, isPremium = false }: HistoryLis
                 <HistoryEmptyState />
             ) : (
                 <div className="space-y-3">
-                    {history.map((item) => (
+                    {keepRenderableHistory(history).map((item) => (
                         <HistoryItem
                             key={item.showIdentifier}
                             item={item}

--- a/lib/hooks/useCloudSync.ts
+++ b/lib/hooks/useCloudSync.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useHistoryStore, usePremiumHistoryStore } from '@/lib/store/history-store';
 import { useFavoritesStore, usePremiumFavoritesStore } from '@/lib/store/favorites-store';
+import { keepRenderableFavorites, keepRenderableHistory } from '@/lib/utils/sync-records';
 import { getProfileId } from '@/lib/store/auth-store';
 
 export function useCloudSync(isPremium = false) {
@@ -19,11 +20,14 @@ export function useCloudSync(isPremium = false) {
       const result = await response.json();
 
       if (result.success && result.data) {
-        if (result.data.history?.length > 0) {
-          historyStore.getState().importHistory(result.data.history);
+        const history = keepRenderableHistory(result.data.history);
+        const favorites = keepRenderableFavorites(result.data.favorites);
+
+        if (history.length > 0) {
+          historyStore.getState().importHistory(history);
         }
-        if (result.data.favorites?.length > 0) {
-          favoritesStore.getState().importFavorites(result.data.favorites);
+        if (favorites.length > 0) {
+          favoritesStore.getState().importFavorites(favorites);
         }
       }
     } catch (error) {

--- a/lib/utils/sync-records.ts
+++ b/lib/utils/sync-records.ts
@@ -1,0 +1,32 @@
+import type { FavoriteItem, VideoHistoryItem } from '@/lib/types';
+
+function hasIdentity(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as { videoId?: unknown; source?: unknown; title?: unknown };
+  const videoId = record.videoId;
+  const hasVideoId = typeof videoId === 'string' ? videoId.length > 0 : typeof videoId === 'number';
+
+  return hasVideoId && typeof record.source === 'string' && typeof record.title === 'string';
+}
+
+/**
+ * Records restored from server-side sync are not guaranteed to be well formed —
+ * they may come from an older schema or a partial write. Rendering one without
+ * `videoId` throws while building the player URL, which takes down the whole
+ * page, so anything lacking a usable identity is dropped on the way in.
+ */
+export function isRenderableHistoryItem(value: unknown): value is VideoHistoryItem {
+  return hasIdentity(value);
+}
+
+export function isRenderableFavoriteItem(value: unknown): value is FavoriteItem {
+  return hasIdentity(value);
+}
+
+export function keepRenderableHistory(items: unknown): VideoHistoryItem[] {
+  return Array.isArray(items) ? items.filter(isRenderableHistoryItem) : [];
+}
+
+export function keepRenderableFavorites(items: unknown): FavoriteItem[] {
+  return Array.isArray(items) ? items.filter(isRenderableFavoriteItem) : [];
+}


### PR DESCRIPTION
# 描述 (Description)

修复同步记录缺少 `videoId` 时**整页崩溃**的问题。

`HistoryItem.tsx:24` 与 `FavoritesItem.tsx:21` 在拼播放地址时直接对 `item.videoId` 调用 `toString()`，而 `getVideoUrl()` 是在渲染 `href` 时被调用的，因此一旦记录缺字段就是渲染期未捕获异常，React 会卸载整棵树 —— 首页白屏、刷新无效，该账号只能靠直接改库恢复。

### 改动内容

- 新增 `lib/utils/sync-records.ts`：可渲染性判定，要求 `videoId`（字符串非空或数字）、`source`、`title` 齐备。
- `lib/hooks/useCloudSync.ts`：从服务端拉取时先过滤，脏数据不进 store。
- `HistoryList` / `FavoritesList`：渲染前再过滤一次，已经落在本地 store 里的旧脏数据也不会触发崩溃。

两层过滤是刻意的：入口那层解决"以后不再进来"，渲染那层解决"已经进来的怎么办"。

## 关联 Issue (Related Issue)

Fixes #228

## 更改类型 (Type of Change)

- [x] 🐛 Bug 修复 (Bug fix)

## 检查清单 (Checklist)

- [x] 我已阅读并遵守 [贡献指南](../CONTRIBUTING.md)
- [x] 我的代码遵循项目的代码风格
- [x] 我已对自己更改的代码进行了自我审查
- [x] 我已注释了难以理解的代码部分
- [x] 我已更新了相应的文档 (如果适用) —— 纯行为修复，未涉及文档
- [x] 我的更改没有产生新的警告或错误
- [x] 我已测试了我的更改，确保其按预期工作

## 验证 (Verification)

**静态检查**

```
npm test                → 73 tests, 73 pass, 0 fail
npx tsc --noEmit        → 改动文件无报错
npx eslint <改动文件>    → 无输出
```

新增文件 31 行，远低于贡献指南的 150 行上限。

**真实浏览器回归测试**

在一台自托管实例上，用 headless Chromium 走完整登录流程，`page.on('pageerror')` 抓未捕获异常：

```
修复前(库里存 {"history":[{"title":"x"}],"favorites":[{"title":"y"}]}):
  页面文字   "This page couldn't load | Reload to try again, or go back."
  pageerror  TypeError: Cannot read properties of undefined (reading 'toString')
               at x (chunks/3824-*.js:56:3328)
               at gu (chunks/4bd1b696-*.js:8:47368)   ← React 渲染栈

修复后(把同样的脏记录原样写回库中再测):
  页面文字   正常渲染:身份、搜索栏、推荐列表、"暂无收藏"、"暂无观看历史"
  pageerror  无
  控制台     无 error/warning
```

也就是说脏记录被静默丢弃，其余功能不受影响。

## 截图/录屏 (Screenshots/Recordings)

崩溃时页面为浏览器的加载失败页，无可用截图价值；修复后为正常首页。
