### PR TITLE
fix(douban): 图片代理按镜像回退，修复境外部署海报大量 500

### DIFF
--- a/app/api/douban/image/route.ts
+++ b/app/api/douban/image/route.ts
@@ -2,6 +2,40 @@ import { NextResponse } from 'next/server';
 
 export const runtime = 'edge';
 
+const REQUEST_HEADERS = {
+    'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+    Accept: 'image/jpeg,image/png,image/gif,*/*;q=0.8',
+    Referer: 'https://movie.douban.com/',
+};
+
+// 豆瓣的 imgN.doubanio.com 互为镜像,但各自解析到不同线路。部分线路(例如 img1
+// 的国内 IP)在境外主机上不可达,fetch 会直接抛错而不是返回状态码,海报因此变成
+// 500。同一路径换个镜像通常就能取到,所以失败时按顺序回退。
+const DOUBAN_IMAGE_HOSTS = ['img9.doubanio.com', 'img3.doubanio.com', 'img2.doubanio.com'];
+
+function buildCandidates(rawUrl: string): string[] {
+    const candidates = [rawUrl];
+
+    try {
+        const parsed = new URL(rawUrl);
+        if (!/^img\d+\.doubanio\.com$/.test(parsed.hostname)) {
+            return candidates;
+        }
+
+        for (const host of DOUBAN_IMAGE_HOSTS) {
+            if (host === parsed.hostname) continue;
+            const alternate = new URL(parsed.toString());
+            alternate.hostname = host;
+            candidates.push(alternate.toString());
+        }
+    } catch {
+        // 非法 URL 留给 fetch 去报错
+    }
+
+    return candidates;
+}
+
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const imageUrl = searchParams.get('url');
@@ -10,51 +44,43 @@ export async function GET(request: Request) {
         return NextResponse.json({ error: 'Missing image URL' }, { status: 400 });
     }
 
-    try {
-        const imageResponse = await fetch(imageUrl, {
-            headers: {
-                'User-Agent':
-                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
-                Accept: 'image/jpeg,image/png,image/gif,*/*;q=0.8',
-                Referer: 'https://movie.douban.com/',
-            },
-        });
+    let lastStatus = 502;
+    let lastError = 'Error fetching image';
+
+    for (const candidate of buildCandidates(imageUrl)) {
+        let imageResponse: Response;
+
+        try {
+            imageResponse = await fetch(candidate, { headers: REQUEST_HEADERS });
+        } catch {
+            // 线路不可达,换下一个镜像
+            continue;
+        }
 
         if (!imageResponse.ok) {
-            return NextResponse.json(
-                { error: imageResponse.statusText },
-                { status: imageResponse.status }
-            );
+            lastStatus = imageResponse.status;
+            lastError = imageResponse.statusText || 'Error fetching image';
+            continue;
         }
-
-        const contentType = imageResponse.headers.get('content-type');
 
         if (!imageResponse.body) {
-            return NextResponse.json(
-                { error: 'Image response has no body' },
-                { status: 500 }
-            );
+            lastStatus = 500;
+            lastError = 'Image response has no body';
+            continue;
         }
 
-        // 创建响应头
         const headers = new Headers();
+        const contentType = imageResponse.headers.get('content-type');
         if (contentType) {
             headers.set('Content-Type', contentType);
         }
-
-        // 设置缓存头
         headers.set('Cache-Control', 'public, max-age=15720000, s-maxage=15720000');
 
-        // 直接返回图片流
-        // @ts-ignore
         return new Response(imageResponse.body, {
             status: 200,
             headers,
         });
-    } catch (error) {
-        return NextResponse.json(
-            { error: 'Error fetching image' },
-            { status: 500 }
-        );
     }
+
+    return NextResponse.json({ error: lastError }, { status: lastStatus });
 }


### PR DESCRIPTION
# 描述 (Description)

修复境外自托管时首页海报大量 500 的问题。

`imgN.doubanio.com` 互为镜像，但各自解析到不同线路。当前 `img1.doubanio.com` 解析到国内 IP `180.97.198.41`，在境外主机上不可达；这种情况下 `fetch` 是**直接抛异常**而不是返回状态码，于是走进 `catch` 一律返回 500。首页一屏推荐里有相当比例的海报因此加载失败。

需要说明的是：这不是豆瓣的反爬。同一张图在同一台机器上换成 `img9` 就能正常取到，说明请求头是有效的，纯粹是线路问题。

```
容器内 fetch 实测(同一张图):
  https://img1.doubanio.com/...  → TypeError: fetch failed
  https://img9.doubanio.com/...  → 200
```

### 改动内容

- 当 host 匹配 `imgN.doubanio.com` 时，按 `img9 → img3 → img2` 的顺序回退，路径原样保留。
- 请求头抽成常量，避免在多次尝试之间重复。
- 保留最后一次的真实状态码，不再把上游的 403 / 404 统一伪装成 500。

非豆瓣域名的 URL 行为不变，只尝试一次。

## 关联 Issue (Related Issue)

无（这是部署环境相关的健壮性修复，未单独开 Issue）。

## 更改类型 (Type of Change)

- [x] 🐛 Bug 修复 (Bug fix)

## 检查清单 (Checklist)

- [x] 我已阅读并遵守 [贡献指南](../CONTRIBUTING.md)
- [x] 我的代码遵循项目的代码风格
- [x] 我已对自己更改的代码进行了自我审查
- [x] 我已注释了难以理解的代码部分
- [x] 我已更新了相应的文档 (如果适用) —— 纯行为修复，未涉及文档
- [x] 我的更改没有产生新的警告或错误
- [x] 我已测试了我的更改，确保其按预期工作

## 验证 (Verification)

```
npm test                → 73 tests, 73 pass, 0 fail
npx tsc --noEmit        → 改动文件无报错
npx eslint <改动文件>    → 无输出
```

真实浏览器加载首页，统计 HTTP >= 400 的响应：

```
修复前: 4 个 500,全部是 /api/douban/image?url=https%3A%2F%2Fimg1.doubanio.com%2F...
修复后: 0 个
```

改动后的文件 85 行，符合贡献指南的 150 行上限。

## 截图/录屏 (Screenshots/Recordings)

修复前首页部分海报为占位图，修复后全部正常显示。
