### PR TITLE
fix: isolate verification from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ README.md
 *.tsbuildinfo
 next-env.d.ts
 .git
+verification

--- a/verification/README.md
+++ b/verification/README.md
@@ -9,6 +9,8 @@ Run the complete read-only validation chain from the repository root:
 The runner installs its pinned tools inside this directory, builds and starts
 KVideo locally, exercises APIs and UI, and writes evidence under
 `verification/artifacts/<run-id>/`. It does not edit application source.
+The repository `.dockerignore` excludes this entire directory so dependencies,
+reports, traces, and screenshots never enter the application build context.
 
 Primary outputs:
 


### PR DESCRIPTION
## Summary

- exclude the entire `verification/` tree from the application Docker build context
- document that verification dependencies, reports, traces, and screenshots are isolated from production builds
- leave application business source and version metadata unchanged

## Root cause

The strict verification suite stores about 1.7 GB of local dependencies and evidence under `verification/`. The root `.dockerignore` did not exclude that directory, so local Docker builds transferred hundreds of megabytes and the context would grow with every report.

## Impact

Docker build context is reduced from roughly 714.91 MB in the earlier build to 848.57 kB. The verification suite remains fully runnable from the repository and does not enter production images.

## Verification

- verification self-tests: 10/10 pass
- verification ESLint: 0 errors, 0 warnings
- all verification `.mjs` syntax checks pass
- all verification-owned files remain <= 150 lines
- `git diff --check` passes
- Docker build succeeds with an 848.57 kB context
- built container starts and reports `currentVersion: 4.9.20`
